### PR TITLE
Added support for project:issue-number queries

### DIFF
--- a/omni-chromium/background.js
+++ b/omni-chromium/background.js
@@ -4,7 +4,7 @@
 
 var CONFIG = [
   [['a', 'author'], AuthorSearcher, 'Commits by author'],
-  [['b', 'bug'], CrbugSearcher, 'Your bugs or a bug ID', 'search "commentby:me"'],
+  [['b', 'bug'], CrbugSearcher, 'Your bugs or a bug ID, or project:bug ID (v8:898)', 'search "commentby:me"'],
   [['c', 'cs'], CodesearchSearcher, 'Chromium code', 'this is the default'],
   [['r', 'rev'], CrrevSearcher, 'Chromium revision'],
 ];

--- a/omni-chromium/crbug.js
+++ b/omni-chromium/crbug.js
@@ -6,10 +6,10 @@ function CrbugSearcher(query) {
 }
 inherits(CrbugSearcher, Searcher);
 
-CrbugSearcher.mainProject = "chromium";
+CrbugSearcher.mainProject_ = "chromium";
 
-CrbugSearcher.projects = [
-  CrbugSearcher.mainProject, "v8", "skia", "webrtc", "pdfium", "angleproject"];
+CrbugSearcher.projects_ = [
+  CrbugSearcher.mainProject_, "v8", "skia", "webrtc", "pdfium", "angleproject"];
 
 CrbugSearcher.prototype.getSuggestionsURL = function() {
   return this.isBugQuery_() ? this.getBugURL_() : this.getIssueListURL_();
@@ -84,7 +84,7 @@ CrbugSearcher.prototype.getBugURL_ = function() {
 };
 
 CrbugSearcher.parseBugNumberQuery_ = function (originalQuery) {
-  var query, parsedQuery, project = CrbugSearcher.mainProject;
+  var query, parsedQuery, project = CrbugSearcher.mainProject_;
   function isBugNumber(bugNumberQuery) {
    return !isNaN(Number.parseInt(bugNumberQuery));
   }
@@ -118,7 +118,7 @@ CrbugSearcher.prototype.getIssueListURL_ = function() {
     encodedQuery.push(encodeURI(component));
   });
   return [
-    'https://code.google.com/p/' + CrbugSearcher.mainProject + '/issues/list?',
+    'https://code.google.com/p/' + CrbugSearcher.mainProject_ + '/issues/list?',
     'q=commentby:me+', encodedQuery.join('+'), '&',
     'sort=-id&',
     'colspec=ID%20Pri%20M%20Iteration%20ReleaseBlock%20Cr%20Status%20Owner%20',

--- a/omni-chromium/crbug.js
+++ b/omni-chromium/crbug.js
@@ -8,7 +8,8 @@ inherits(CrbugSearcher, Searcher);
 
 CrbugSearcher.mainProject = "chromium";
 
-CrbugSearcher.projects = [CrbugSearcher.mainProject, "v8", "skia", "webrtc", "pdfium", "angleproject"];
+CrbugSearcher.projects = [
+  CrbugSearcher.mainProject, "v8", "skia", "webrtc", "pdfium", "angleproject"];
 
 CrbugSearcher.prototype.getSuggestionsURL = function() {
   return this.isBugQuery_() ? this.getBugURL_() : this.getIssueListURL_();
@@ -75,14 +76,14 @@ CrbugSearcher.prototype.getSearchURL = function() {
 };
 
 CrbugSearcher.prototype.isBugQuery_ = function() {
-  return !!CrbugSearcher.parseBugNumberQuery(this.query);
+  return !!CrbugSearcher.parseBugNumberQuery_(this.query);
 };
 
 CrbugSearcher.prototype.getBugURL_ = function() {
   return CrbugSearcher.getCodeGoogleComIssue_(this.query);
 };
 
-CrbugSearcher.parseBugNumberQuery = function (originalQuery) {
+CrbugSearcher.parseBugNumberQuery_ = function (originalQuery) {
   var query, parsedQuery, project = CrbugSearcher.mainProject;
   function isBugNumber(bugNumberQuery) {
    return !isNaN(Number.parseInt(bugNumberQuery));
@@ -105,8 +106,9 @@ CrbugSearcher.parseBugNumberQuery = function (originalQuery) {
 };
 
 CrbugSearcher.getCodeGoogleComIssue_ = function(query) {
-  var parsedQuery = CrbugSearcher.parseBugNumberQuery(query);
-  return 'https://code.google.com/p/' + parsedQuery.project + '/issues/detail?id=' + parsedQuery.issueNumber;
+  var parsedQuery = CrbugSearcher.parseBugNumberQuery_(query);
+  return 'https://code.google.com/p/' + parsedQuery.project +
+		'/issues/detail?id=' + parsedQuery.issueNumber;
 };
 
 CrbugSearcher.prototype.getIssueListURL_ = function() {

--- a/omni-chromium/crbug.js
+++ b/omni-chromium/crbug.js
@@ -6,6 +6,10 @@ function CrbugSearcher(query) {
 }
 inherits(CrbugSearcher, Searcher);
 
+CrbugSearcher.mainProject = "chromium";
+
+CrbugSearcher.projects = [CrbugSearcher.mainProject, "v8", "skia", "webrtc", "pdfium", "angleproject"];
+
 CrbugSearcher.prototype.getSuggestionsURL = function() {
   return this.isBugQuery_() ? this.getBugURL_() : this.getIssueListURL_();
 };
@@ -33,7 +37,7 @@ CrbugSearcher.prototype.getSuggestions = function(response) {
     }];
   }
 
-  var suggestions = []
+  var suggestions = [];
   Array.prototype.forEach.call(
       dom.querySelectorAll('#resultstable tr:not(#headingrow)'),
       function(row) {
@@ -71,15 +75,38 @@ CrbugSearcher.prototype.getSearchURL = function() {
 };
 
 CrbugSearcher.prototype.isBugQuery_ = function() {
-  return !isNaN(Number.parseInt(this.query));
+  return !!CrbugSearcher.parseBugNumberQuery(this.query);
 };
 
 CrbugSearcher.prototype.getBugURL_ = function() {
   return CrbugSearcher.getCodeGoogleComIssue_(this.query);
 };
 
-CrbugSearcher.getCodeGoogleComIssue_ = function(issueNumber) {
-  return 'https://code.google.com/p/chromium/issues/detail?id=' + issueNumber;
+CrbugSearcher.parseBugNumberQuery = function (originalQuery) {
+  var query, parsedQuery, project = CrbugSearcher.mainProject;
+  function isBugNumber(bugNumberQuery) {
+   return !isNaN(Number.parseInt(bugNumberQuery));
+  }
+
+  query = originalQuery;
+  if (isBugNumber(query)) {
+    return {project: project, issueNumber: query};
+  }
+
+  parsedQuery = originalQuery.split(":");
+  project = parsedQuery[0];
+  query = parsedQuery[1];
+  
+  if (CrbugSearcher.projects.indexOf(project) !== -1 && isBugNumber(query)) {
+    return {project: project, issueNumber: query};
+  }
+  
+  return;
+};
+
+CrbugSearcher.getCodeGoogleComIssue_ = function(query) {
+  var parsedQuery = CrbugSearcher.parseBugNumberQuery(query);
+  return 'https://code.google.com/p/' + parsedQuery.project + '/issues/detail?id=' + parsedQuery.issueNumber;
 };
 
 CrbugSearcher.prototype.getIssueListURL_ = function() {
@@ -89,7 +116,7 @@ CrbugSearcher.prototype.getIssueListURL_ = function() {
     encodedQuery.push(encodeURI(component));
   });
   return [
-    'https://code.google.com/p/chromium/issues/list?',
+    'https://code.google.com/p/' + CrbugSearcher.mainProject + '/issues/list?',
     'q=commentby:me+', encodedQuery.join('+'), '&',
     'sort=-id&',
     'colspec=ID%20Pri%20M%20Iteration%20ReleaseBlock%20Cr%20Status%20Owner%20',

--- a/omni-chromium/manifest.json
+++ b/omni-chromium/manifest.json
@@ -31,5 +31,5 @@
     "storage",
     "https://code.google.com/p/cs/codesearch/codesearch/json/*"
   ],
-  "version": "9.0"
+  "version": "10.0"
 }


### PR DESCRIPTION
Added support for project specific issues (Chromium is the still default when the project name is omitted). b:v8:989, b:skia:822 and so on.
This is not optimized at all (it is called several times per query - creating an object every time - instead of being cached and re-used), but so was the previous code (though it was much simpler).